### PR TITLE
Update nova_anno_utils.py

### DIFF
--- a/hcai_datasets/hcai_nova_dynamic/utils/nova_anno_utils.py
+++ b/hcai_datasets/hcai_nova_dynamic/utils/nova_anno_utils.py
@@ -148,7 +148,7 @@ class DiscreteAnnotation(Annotation):
         else:
             # Creating numpy array of annotations for fast access
             # Splitting the annotations into interval and data array
-            self.data_interval = self.dataframe[["from", "to"]].values.astype(np.int)
+            self.data_interval = self.dataframe[["from", "to"]].values.astype(int)
             self.data_values = self.dataframe[["id", "conf"]].values
 
     def get_label_for_frame_legacy(self, start, end):
@@ -251,7 +251,7 @@ class FreeAnnotation(Annotation):
         else:
             # Creating numpy array of annotations for fast access
             # Splitting the annotations into interval and data array
-            self.data_interval = self.dataframe[["from", "to"]].values.astype(np.int)
+            self.data_interval = self.dataframe[["from", "to"]].values.astype(int)
             self.data_values = self.dataframe[["name", "conf"]].values
 
     def get_label_for_frame_legacy(self, start, end):


### PR DESCRIPTION
Ad
```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```